### PR TITLE
fix: typo /esModuleInterOp/esModuleInterop/

### DIFF
--- a/content/entry/2021-09-09/answer-named-export/index.mdx
+++ b/content/entry/2021-09-09/answer-named-export/index.mdx
@@ -93,7 +93,7 @@ tags:
 
 それな（同意）
 
-TypeScriptに`esModuleInterOp`が導入される前はCommonJSとの相互運用性がかなり厄介な問題でしたが、今は本質的な問題とはなりません。
+TypeScriptに`esModuleInterop`が導入される前はCommonJSとの相互運用性がかなり厄介な問題でしたが、今は本質的な問題とはなりません。
 
 > また、「default exportだと補完が効かない」と思っている人が多いようですが、それはanonymous default exportだからです。名前は付けてください。
 


### PR DESCRIPTION
Typoだと思われたのでPull Requestしました

確認に利用したURL
https://www.typescriptlang.org/tsconfig#esModuleInterop

GitHub上でいじると最終行に改行が挿入されてしまうようです。
気になるようであれば無視してください。